### PR TITLE
Do not load balance from snx

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -36,7 +36,7 @@ tcr:
     lists:
       - networkId: 1
         listId: 1
-        contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0'        
+        contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0'
 
       - networkId: 4
         contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b'

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -36,7 +36,7 @@ tcr:
     lists:
       - networkId: 1
         listId: 1
-        contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0'
+        contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0'        
 
       - networkId: 4
         contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b'
@@ -107,6 +107,7 @@ disabledTokens:
       description: This token is disabled for trading and depositing. sUSD will be deprecated and replaced by another token at the end of July 2020.  Go to https://www.synthetix.io for more information
       reason: DEPRECATED
       url: https://docs.synthetix.io/integrations/guide/#proxy-deprecation
+      display: false # do not allow to use it, it will fail even trying to get the tokens
 
     - address: '0xC011A72400E58ecD99Ee497CF89E3775d4bd732F'
       name: Synthetix Network Token (deprecated)
@@ -114,6 +115,7 @@ disabledTokens:
       description: This token is disabled for trading and depositing. SNX will be deprecated and replaced by another token at the end of July 2020.  Go to https://www.synthetix.io for more information
       reason: DEPRECATED
       url: https://docs.synthetix.io/integrations/guide/#proxy-deprecation
+      display: false # do not allow to use it, it will fail even trying to get the tokens
 
     - address: '0x45804880De22913dAFE09f4980848ECE6EcbAf78'
       name: Paxos Gold

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -107,7 +107,7 @@ disabledTokens:
       description: This token is disabled for trading and depositing. sUSD will be deprecated and replaced by another token at the end of July 2020.  Go to https://www.synthetix.io for more information
       reason: DEPRECATED
       url: https://docs.synthetix.io/integrations/guide/#proxy-deprecation
-      display: false # do not allow to use it, it will fail even trying to get the tokens
+      display: false # Do not display it. It will fail even trying to get the token balances
 
     - address: '0xC011A72400E58ecD99Ee497CF89E3775d4bd732F'
       name: Synthetix Network Token (deprecated)
@@ -115,7 +115,7 @@ disabledTokens:
       description: This token is disabled for trading and depositing. SNX will be deprecated and replaced by another token at the end of July 2020.  Go to https://www.synthetix.io for more information
       reason: DEPRECATED
       url: https://docs.synthetix.io/integrations/guide/#proxy-deprecation
-      display: false # do not allow to use it, it will fail even trying to get the tokens
+      display: false # Do not display it. It will fail even trying to get the token balances
 
     - address: '0x45804880De22913dAFE09f4980848ECE6EcbAf78'
       name: Paxos Gold

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -40,7 +40,6 @@ function addAdditionalTokenDetails(networkId: number): (token: TokenDetails) => 
     if (tokenOverride) {
       token.override = tokenOverride
       token.disabled = true
-      token.display = tokenOverride.display !== false
       // override only keys present in both token and tokenOverride
       Object.keys(token).forEach((key) => {
         if (tokenOverride[key] !== undefined) token[key] = tokenOverride[key]

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -40,6 +40,7 @@ function addAdditionalTokenDetails(networkId: number): (token: TokenDetails) => 
     if (tokenOverride) {
       token.override = tokenOverride
       token.disabled = true
+      token.display = tokenOverride.display !== false
       // override only keys present in both token and tokenOverride
       Object.keys(token).forEach((key) => {
         if (tokenOverride[key] !== undefined) token[key] = tokenOverride[key]

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -273,7 +273,10 @@ export function getTokensFactory(factoryParams: {
     const filteredAddressesAndIds = await _getFilteredIdsMap(networkId, numTokens, tokensConfig)
 
     // Get token details for each filtered token
-    const tokenDetails = await _fetchTokenDetails(networkId, filteredAddressesAndIds, tokensConfig)
+    let tokenDetails = await _fetchTokenDetails(networkId, filteredAddressesAndIds, tokensConfig)
+
+    // Remove the deprecated tokens that shouldn't even be displayed in the UI
+    tokenDetails = tokenDetails.filter((tokenDetails) => tokenDetails.display)
 
     // Sort tokens
     // note that sort mutates tokenDetails

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -61,6 +61,7 @@ export interface TokenOverride {
   reason?: string
   description?: string
   url?: string
+  display?: boolean
 }
 
 export interface DisabledTokens {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface TokenDetails extends TokenDex {
   disabled?: boolean
   override?: TokenOverride
   priority?: number
+  display?: boolean
 }
 
 export interface BalanceDetails {


### PR DESCRIPTION
WIP, try not to load some tokens that we know they break when trying to load their balance

For this, one new field `display` is added to the deprecated list of tokens. So we can indicated that a deprecated token shouldn't even be displayed (because for example, we cannot load the balances)


Applies filter early in the token loading strategy:
![image](https://user-images.githubusercontent.com/2352112/98971094-02686580-2511-11eb-851d-6262b63662cd.png)


But for some reason, it is loading them:
![image](https://user-images.githubusercontent.com/2352112/98971123-0dbb9100-2511-11eb-8e28-d218658b4b37.png)
