### PR TITLE
Use same TCR as mesa for testing

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -36,6 +36,7 @@ tcr:
     lists:
       - networkId: 1
         listId: 1
+        # contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0' # Testing TCR with rare tokens
         contractAddress: '0x93DB90445B76329e9ed96ECd74e76D8fbf2590d8'
 
       - networkId: 4

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -36,7 +36,7 @@ tcr:
     lists:
       - networkId: 1
         listId: 1
-        contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0'
+        contractAddress: '0x93DB90445B76329e9ed96ECd74e76D8fbf2590d8'
 
       - networkId: 4
         contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b'

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -36,7 +36,7 @@ describe('Test config defaults', () => {
           {
             networkId: 1,
             listId: 1,
-            contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+            contractAddress: '0x93DB90445B76329e9ed96ECd74e76D8fbf2590d8',
           },
           {
             networkId: 4,


### PR DESCRIPTION
Use same TCR as mesa for testing

Any project can for dex-react and use their own TCR. For testing the TCR functionality, we could use same as Mesa, since I assume they would provide a rationale on their listing and deprecate old tokens (and check for compatibilities before listing) 

I left as a comment the old TCR we were using, since it can be handy to use back in the future for some tests.