### PR TITLE
Add existing wallet component to header.

### DIFF
--- a/src/components/layout/GenericLayout/NavTools/index.tsx
+++ b/src/components/layout/GenericLayout/NavTools/index.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components'
 
 import { MEDIA } from 'const'
 import { NavStyled } from '../Menu'
-import { Frame } from 'components/common/Frame'
+
+// Components
+import UserWallet from 'components/UserWallet'
 
 import SettingsImage from 'assets/img/settings.svg'
 import SettingsImageWhite from 'assets/img/settings-white.svg'
@@ -90,8 +92,6 @@ const Wrapper = styled(NavStyled)`
     }
   }
 `
-
-const UserWallet: React.FC = () => <Frame>User Wallet</Frame>
 
 type Props = React.PropsWithChildren<{
   hasWallet?: boolean


### PR DESCRIPTION
Adding our existing wallet component to the header of V2. What's the best way to apply complete new styles for the wallet, without having to inherit from the existing styled component? (`components/UserWallet/UserWallet.styled`)