### PR TITLE
Token image fetch optimization

### DIFF
--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -76,7 +76,14 @@ const useFailOnceImage = ({ address, addressMainnet, symbol, name }: Omit<Props,
   }, [address, addressMainnet, symbol, name])
 }
 
+export const TokenImg: React.FC<Props> = (props) => {
+  const { faded } = props
+
   const imageProps = useFailOnceImage(props)
+
+  return <Wrapper {...imageProps} faded={faded} />
+}
+
 export const TokenImgWrapper = styled(TokenImg)`
   margin: 0 1rem 0 0;
 `

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -13,9 +13,15 @@ const Wrapper = styled.img<WrapperProps>`
   padding: 2px;
   opacity: ${(props): number => (props.faded ? 0.4 : 1)};
 `
+// keep track of 404 token images
+// so we don't retry fetching them
+const failedTokenImages = new Set<string>()
 
 function _loadFallbackTokenImage(event: React.SyntheticEvent<HTMLImageElement>): void {
   const image = event.currentTarget
+
+  failedTokenImages.add(image.src)
+
   image.src = unknownTokenImg
 }
 
@@ -58,11 +64,14 @@ export const TokenImg: React.FC<Props> = (props) => {
     ? tokensIconsRequire(iconFile).default
     : getImageUrl(addressMainnet || address)
 
+  // if we know the image failed before, use fallback image right away
+  const imgSrc = iconFileUrl && !failedTokenImages.has(iconFileUrl) ? iconFileUrl : unknownTokenImg
+
   // TODO: Simplify safeTokenName signature, it doesn't need the addressMainnet or id!
   // https://github.com/gnosis/dex-react/issues/1442
   const safeName = safeTokenName({ address, symbol, name })
 
-  return <Wrapper alt={safeName} src={iconFileUrl} onError={_loadFallbackTokenImage} {...props} />
+  return <Wrapper alt={safeName} src={imgSrc} onError={_loadFallbackTokenImage} {...props} />
 }
 
 export const TokenImgWrapper = styled(TokenImg)`


### PR DESCRIPTION
After a suggestion by @biocom 
There are a lot of `GET https://.../<address>/logo.png 404` errors in the console for token images that aren't there. And while we can't get rid of these reports (as these are browser fetch errors), we can not retry failed images (on route change, on `TokenImage` remount)

So let's keep track of failed images and use fallback right away.

Also stop passing extra props to `Wrapper`s, that's plain bad manners :stern_look: