### PR TITLE
[V2 #1660 Style Rework] - Enhance ThemeProvider

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import styled, { css, /* DefaultTheme, */ ThemeProvider } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { ThemeValue, variants } from 'styled-theming'
 
 import { COLOURS, BASE_STYLES } from 'styles'
+import ThemeProvider, { Theme } from 'theme'
 
 const {
   white,
@@ -50,7 +51,7 @@ export type ButtonSizeVariations = 'default' | 'small' | 'big'
 // <ButtonBase kind="danger" />
 export const ButtonTheme = variants('mode', 'variant', {
   default: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: ${mainGradient};
 
@@ -58,7 +59,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         background: ${mainGradientDarker};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${white};
       background: ${mainGradient};
 
@@ -71,7 +72,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     return this.default
   },
   secondary: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${blue};
       background: ${bgLight};
       border-color: ${blue};
@@ -80,7 +81,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         background: ${bgDark};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${blue};
       background: ${bgDark};
       border-color: ${blue};
@@ -92,7 +93,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     `,
   },
   success: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: ${successLight};
 
@@ -101,7 +102,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         border-color: ${successDark};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${white};
       background: ${successDark};
 
@@ -112,7 +113,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     `,
   },
   danger: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: ${dangerLight};
 
@@ -121,7 +122,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         border-color: ${dangerDark};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${white};
       background: ${dangerDark};
 
@@ -132,7 +133,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     `,
   },
   warning: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: ${warningLight};
 
@@ -141,7 +142,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         border-color: ${warningDark};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${white};
       background: ${warningDark};
 
@@ -152,7 +153,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     `,
   },
   cancel: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: transparent;
 
@@ -160,7 +161,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         background: ${blueDark};
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ${blue};
       background: transparent;
 
@@ -171,7 +172,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     `,
   },
   disabled: {
-    dark: css`
+    [Theme.DARK]: css`
       color: ${disabledLightOpaque};
       background: ${disabledLight};
     `,
@@ -180,7 +181,7 @@ export const ButtonTheme = variants('mode', 'variant', {
     },
   },
   theme: {
-    light: css`
+    [Theme.LIGHT]: css`
       color: ${white};
       background: lightsalmon;
 
@@ -189,7 +190,7 @@ export const ButtonTheme = variants('mode', 'variant', {
         background: darkorange;
       }
     `,
-    dark: css`
+    [Theme.DARK]: css`
       color: ghostwhite;
       background: purple;
 
@@ -233,9 +234,7 @@ const ColouredAndSizedButtonBase = styled(ColouredButtonBase)`
 // Wrap ColouredAndSizedButtonsBase in it's own ThemeProvider which takes the toplevel app theme
 // ThemeProvider and interpolate over it's props
 const ThemeWrappedButtonBase: React.FC<React.ButtonHTMLAttributes<Element>> = ({ children, ...restProps }) => (
-  // TODO: fix when ThemePRovider is properly coded in
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  <ThemeProvider theme={({ mode }: any): any => ({ mode, componentKey: 'button' })}>
+  <ThemeProvider componentKey="button">
     <ColouredAndSizedButtonBase {...restProps}>{children}</ColouredAndSizedButtonBase>
   </ThemeProvider>
 )

--- a/src/reducers-actions/tokenRow.ts
+++ b/src/reducers-actions/tokenRow.ts
@@ -1,6 +1,6 @@
 import { Actions } from 'reducers-actions'
 
-export const enum ActionTypes {
+export enum ActionTypes {
   SET_ENABLING = 'enabling',
   SET_ENABLED = 'enabled',
   SET_CLAIMING = 'claiming',

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { MemoryRouter } from 'react-router'
 
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
@@ -7,7 +7,16 @@ import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/typ
 import { ApolloProvider } from '@apollo/client'
 import { ApolloClient, InMemoryCache } from '@apollo/client'
 import { useForm, FormProvider, UseFormOptions } from 'react-hook-form'
-import { BASE_COLOURS, DARK_COLOURS, LIGHT_COLOURS, StaticGlobalStyle, Theme } from 'theme'
+import { getThemePalette, StaticGlobalStyle, Theme } from 'theme'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faMoon, faLightbulb } from '@fortawesome/free-regular-svg-icons'
+
+import { ThemeToggle } from 'components/common/Button'
+import { useThemeManager } from 'hooks/useThemeManager'
+
+import { withGlobalContext } from 'hooks/useGlobalState'
+import { INITIAL_STATE, rootReducer } from 'reducers-actions'
 
 export const GlobalStyles = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
   <>
@@ -16,45 +25,31 @@ export const GlobalStyles = (DecoratedStory: () => StoryFnReactReturnType): JSX.
   </>
 )
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faMoon, faSun } from '@fortawesome/free-regular-svg-icons'
+const ThemeTogglerUnwrapped: React.FC = ({ children }) => {
+  const [themeMode, setThemeMode] = useThemeManager()
+  const [themePalette, isDarkMode] = useMemo(() => [getThemePalette(themeMode), themeMode === Theme.DARK], [themeMode])
 
-import { ThemeToggle } from 'components/common/Button'
-import { DefaultTheme, ThemeProvider } from 'styled-components'
-
-// TODO: remove and implement a theme managing hook
-function useMockThemeManager(isDarkMode: boolean): DefaultTheme {
-  const mode = isDarkMode ? Theme.DARK : Theme.LIGHT
-  const COLOUR_PALETTE = isDarkMode ? DARK_COLOURS : LIGHT_COLOURS
-  return {
-    mode,
-    ...BASE_COLOURS,
-    ...COLOUR_PALETTE,
-  }
-}
-
-export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => {
-  const [darkMode, setDarkMode] = React.useState(true)
-  // TODO: remove and implement a theme managing hook
-  const theme: DefaultTheme = useMockThemeManager(darkMode)
-
-  const handleDarkMode = (): void => setDarkMode((darkMode) => !darkMode)
+  const handleDarkMode = (): void => setThemeMode(themeMode === Theme.DARK ? Theme.LIGHT : Theme.DARK)
 
   return (
     <>
-      <ThemeProvider theme={theme}>
-        <Frame style={{ background: theme.bg1 }}>{DecoratedStory()}</Frame>
-        {/* Cheeky use of ButtonBase here :P */}
-        <ThemeToggle onClick={handleDarkMode} mode={darkMode}>
-          <FontAwesomeIcon icon={darkMode ? faMoon : faSun} />
-        </ThemeToggle>
-        <br />
-        <br />
-        <code>Current theme: {theme.mode.toUpperCase()}</code>
-      </ThemeProvider>
+      <Frame style={{ background: themePalette.bg1 }}>{children}</Frame>
+      {/* Cheeky use of ButtonBase here :P */}
+      <ThemeToggle onClick={handleDarkMode} mode={isDarkMode}>
+        <FontAwesomeIcon icon={isDarkMode ? faMoon : faLightbulb} />
+      </ThemeToggle>
+      <br />
+      <br />
+      <code>Current theme: {themeMode.toUpperCase()}</code>
     </>
   )
 }
+const WrappedThemeToggler: React.FC = withGlobalContext(ThemeTogglerUnwrapped, INITIAL_STATE, rootReducer)
+
+// Redux aware ThemeToggler - necessary for Theme
+export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => (
+  <WrappedThemeToggler>{DecoratedStory()}</WrappedThemeToggler>
+)
 
 export const Router = (DecoratedStory: () => JSX.Element): JSX.Element => (
   <MemoryRouter>{DecoratedStory()}</MemoryRouter>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,2 +1,0 @@
-export * from './styles'
-export * from './types'

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -9,7 +9,10 @@ import { getThemePalette } from './utils'
 import { useThemeMode } from 'hooks/useThemeManager'
 
 // Extension/override of styled-components' ThemeProvider but with our own constructed theme object
-const ThemeProvider: React.FC<{ themeExtension: DefaultTheme['components'] }> = ({ children, themeExtension }) => {
+const ThemeProvider: React.FC<{ componentKey: Partial<DefaultTheme['componentKey']> }> = ({
+  children,
+  componentKey,
+}) => {
   const themeMode = useThemeMode()
 
   const themeObject = useMemo(() => {
@@ -22,11 +25,11 @@ const ThemeProvider: React.FC<{ themeExtension: DefaultTheme['components'] }> = 
       // unfold in any extensions
       // for example to make big/small buttons -> see src/components/Button ThemeWrappedButtonBase
       // to see it in action
-      components: themeExtension,
+      componentKey,
     }
 
     return computedTheme
-  }, [themeMode, themeExtension])
+  }, [themeMode, componentKey])
 
   // We want to pass the ThemeProvider theme to all children implicitly, no need to manually pass it
   return (

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,0 +1,44 @@
+export * from './styles'
+export * from './types'
+export * from './utils'
+
+import React, { useMemo } from 'react'
+import { DefaultTheme, ThemeProvider as StyledComponentsThemeProvider } from 'styled-components'
+
+import { getThemePalette } from './utils'
+import { useThemeMode } from 'hooks/useThemeManager'
+
+// Extension/override of styled-components' ThemeProvider but with our own constructed theme object
+const ThemeProvider: React.FC<{ themeExtension: DefaultTheme['components'] }> = ({ children, themeExtension }) => {
+  const themeMode = useThemeMode()
+
+  const themeObject = useMemo(() => {
+    const themePalette = getThemePalette(themeMode)
+
+    const computedTheme: DefaultTheme = {
+      // Compute the app colour pallette using the passed in themeMode
+      ...themePalette,
+      mode: themeMode,
+      // unfold in any extensions
+      // for example to make big/small buttons -> see src/components/Button ThemeWrappedButtonBase
+      // to see it in action
+      components: themeExtension,
+    }
+
+    return computedTheme
+  }, [themeMode, themeExtension])
+
+  // We want to pass the ThemeProvider theme to all children implicitly, no need to manually pass it
+  return (
+    <StyledComponentsThemeProvider theme={themeObject}>
+      {React.Children.map(
+        children,
+        (childWithTheme) =>
+          // make sure child is a valid react element as children by default can be type string|null|number
+          React.isValidElement(childWithTheme) && React.cloneElement(childWithTheme, { theme: themeObject }),
+      )}
+    </StyledComponentsThemeProvider>
+  )
+}
+
+export default ThemeProvider

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -33,7 +33,6 @@ export interface Colors {
 }
 
 export enum Theme {
-  AUTO = 'AUTO',
   DARK = 'DARK',
   LIGHT = 'LIGHT',
 }

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -1,0 +1,18 @@
+import { Theme, Colors, LIGHT_COLOURS, DARK_COLOURS, BASE_COLOURS } from 'theme'
+
+export function getThemePalette(colourTheme: Theme): Colors {
+  let THEME_COLOURS = LIGHT_COLOURS
+
+  switch (colourTheme) {
+    case Theme.LIGHT:
+      THEME_COLOURS = LIGHT_COLOURS
+      break
+    case Theme.DARK:
+      THEME_COLOURS = DARK_COLOURS
+      break
+  }
+  return {
+    ...BASE_COLOURS,
+    ...THEME_COLOURS,
+  }
+}

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -10,6 +10,8 @@ export function getThemePalette(colourTheme: Theme): Colors {
     case Theme.DARK:
       THEME_COLOURS = DARK_COLOURS
       break
+    default:
+      THEME_COLOURS = DARK_COLOURS
   }
   return {
     ...BASE_COLOURS,


### PR DESCRIPTION
Part of #1660 and :water_buffalo: 's into #1667 

Enhances the default `styled-components` `ThemeProvider` wrapper and passes in our `theme` - also adds the benefit of implicitly passing it to any children

1. uses the `useThemeManager` hook and redux data from previous PR to detect selected theme and adjust accordingly.
2. Wraps ThemeToggler inside `storybook > decorators` with `withGlobalContext` inorder to access global state and use the theme provider
3. adds a `utils` file inside `theme` for some common utils. `getColourPalette` returns the `themeMode` specific `colourPalette`